### PR TITLE
Update cookie auth docs to fix missing links

### DIFF
--- a/aspnet-core/xml/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.xml
+++ b/aspnet-core/xml/Microsoft.AspNetCore.Authentication.Cookies/CookieAuthenticationOptions.xml
@@ -83,9 +83,9 @@
             Determines the settings used to create the cookie.
             </para>
           <para>
-            <seealso cref="P:Microsoft.AspNetCore.Http.CookieBuilder.SameSite" /> defaults to <see cref="F:Microsoft.AspNetCore.Http.SameSiteMode.Lax" />.
-            <seealso cref="P:Microsoft.AspNetCore.Http.CookieBuilder.HttpOnly" /> defaults to <c>true</c>.
-            <seealso cref="P:Microsoft.AspNetCore.Http.CookieBuilder.SecurePolicy" /> defaults to <see cref="F:Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest" />.
+            <see cref="P:Microsoft.AspNetCore.Http.CookieBuilder.SameSite" /> defaults to <see cref="F:Microsoft.AspNetCore.Http.SameSiteMode.Lax" />.
+            <see cref="P:Microsoft.AspNetCore.Http.CookieBuilder.HttpOnly" /> defaults to <c>true</c>.
+            <see cref="P:Microsoft.AspNetCore.Http.CookieBuilder.SecurePolicy" /> defaults to <see cref="F:Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest" />.
             </para>
         </summary>
         <value>To be added.</value>
@@ -96,15 +96,15 @@
             system uses the cookie authentication handler multiple times.
             </para>
           <para>
-            <seealso cref="P:Microsoft.AspNetCore.Http.CookieBuilder.SameSite" /> determines if the browser should allow the cookie to be attached to same-site or cross-site requests.
+            <see cref="P:Microsoft.AspNetCore.Http.CookieBuilder.SameSite" /> determines if the browser should allow the cookie to be attached to same-site or cross-site requests.
             The default is Lax, which means the cookie is only allowed to be attached to cross-site requests using safe HTTP methods and same-site requests.
             </para>
           <para>
-            <seealso cref="P:Microsoft.AspNetCore.Http.CookieBuilder.HttpOnly" /> determines if the browser should allow the cookie to be accessed by client-side javascript.
+            <see cref="P:Microsoft.AspNetCore.Http.CookieBuilder.HttpOnly" /> determines if the browser should allow the cookie to be accessed by client-side javascript.
             The default is true, which means the cookie will only be passed to http requests and is not made available to script on the page.
             </para>
           <para>
-            <seealso cref="P:Microsoft.AspNetCore.Http.CookieBuilder.Expiration" /> is currently ignored. Use <see cref="P:Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions.ExpireTimeSpan" /> to control lifetime of cookie authentication.
+            <see cref="P:Microsoft.AspNetCore.Http.CookieBuilder.Expiration" /> is currently ignored. Use <see cref="P:Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationOptions.ExpireTimeSpan" /> to control lifetime of cookie authentication.
             </para>
         </remarks>
       </Docs>


### PR DESCRIPTION
Updated the `<seealso>` tags to `<see>` tags so that the links will show up. [Currently](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.cookies.cookieauthenticationoptions.cookie), anything on the page with `<seealso>` tags is not displayed.