### PR TITLE
Third person summary

### DIFF
--- a/aspnet-core/xml/Microsoft.AspNetCore.WebUtilities/QueryHelpers.xml
+++ b/aspnet-core/xml/Microsoft.AspNetCore.WebUtilities/QueryHelpers.xml
@@ -107,7 +107,7 @@
       <Docs>
         <param name="queryString">The raw query string value, with or without the leading '?'.</param>
         <summary>
-            Parse a query string into its component key and value parts.
+            Parses a query string into its component key and value parts.
             </summary>
         <returns>A collection of parsed keys and values, null if there are no entries.</returns>
         <remarks>To be added.</remarks>
@@ -136,7 +136,7 @@
       <Docs>
         <param name="queryString">The raw query string value, with or without the leading '?'.</param>
         <summary>
-            Parse a query string into its component key and value parts.
+            Parses a query string into its component key and value parts.
             </summary>
         <returns>A collection of parsed keys and values.</returns>
         <remarks>To be added.</remarks>


### PR DESCRIPTION
Member summaries throughout the .NET SDK use third person. The summaries have an implied "This method", "This property", etc. prefix. For example, "This method parses a query string...". This PR changes the summaries from second person (i.e. the command, "Parse a query string...") to third person. A scan should be made for other such inconsistencies.