### PR TITLE
Indicate how to represent no subprotocol

### DIFF
--- a/aspnet-core/xml/Microsoft.AspNetCore.Http/WebSocketManager.xml
+++ b/aspnet-core/xml/Microsoft.AspNetCore.Http/WebSocketManager.xml
@@ -65,6 +65,7 @@
             </summary>
         <returns>A task representing the completion of the transition.</returns>
         <remarks>To be added.</remarks>
+        <exception cref="System.ArgumentException">The subprotocol is an empty string. Use "null" to specify no value.</exception>
       </Docs>
     </Member>
     <Member MemberName="AcceptWebSocketAsync">


### PR DESCRIPTION
It's also good to document exceptions. Sure beat trial and error. :-)