### PR TITLE
Improve summary for OpenIdConnectOptions.RemoteSignOutPath

### DIFF
--- a/aspnet-core/xml/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.xml
+++ b/aspnet-core/xml/Microsoft.AspNetCore.Authentication.OpenIdConnect/OpenIdConnectOptions.xml
@@ -454,7 +454,7 @@
       </ReturnValue>
       <Docs>
         <summary>
-            Requests received on this path will cause the handler to invoke SignOut using the SignInScheme.
+            Requests received on this path will cause the handler to invoke SignOut using the SignOutScheme, or if that property is not set, SignInScheme.
             </summary>
         <value>To be added.</value>
         <remarks>To be added.</remarks>


### PR DESCRIPTION
A call into the OpenID Connect authentication middleware at the path configured in `OpenIdConnectOptions.RemoteSignOutPath` will first try to sign out using the property `SignOutScheme` before falling back to `SignInScheme`. This is clear on the documentation for the `SignOutScheme` property but not on `RemoteSignOutPath`. This wording is more precise and helps users in cases where they need a different scheme than for sign-in. 