### PR TITLE
Updating description for PasswordSignInAsync

### DIFF
--- a/aspnet-core/xml/Microsoft.AspNetCore.Identity/SignInManager`1.xml
+++ b/aspnet-core/xml/Microsoft.AspNetCore.Identity/SignInManager`1.xml
@@ -722,7 +722,7 @@
         <param name="user">The user to sign in.</param>
         <param name="password">The password to attempt to sign in with.</param>
         <param name="isPersistent">Flag indicating whether the sign-in cookie should persist after the browser is closed.</param>
-        <param name="lockoutOnFailure">Flag indicating if the user account should be locked if the sign in fails.</param>
+        <param name="lockoutOnFailure">Flag indicating if the failed access count for this user should increase by 1 should the sign-in fail. (Meaning that if this is the last attempt the user can make to sign in before they are locked out and the sign-in fails, they will be locked out.)</param>
         <summary>
             Attempts to sign in the specified <paramref name="user" /> and <paramref name="password" /> combination
             as an asynchronous operation.


### PR DESCRIPTION
The current description is misleading for the 4th parameter in the method. It might be read as "if the lockoutOnFailure parameter is set to true, the user will be locked out, even if this is not their last possible attempt (for example if this is their 2nd attempt to sign in and the maximum is 5 they will still be locked out if the sign-in fails)", even though this is not true. The parameter only determines whether the failed access acount should increase by 1 if the sign-in fails.

I believe the description I gave fits better.