### PR TITLE
Improve XML docs for ActionResultObjectValueAttribute

### DIFF
--- a/aspnet-core/xml/Microsoft.AspNetCore.Mvc.Infrastructure/ActionResultObjectValueAttribute.xml
+++ b/aspnet-core/xml/Microsoft.AspNetCore.Mvc.Infrastructure/ActionResultObjectValueAttribute.xml
@@ -21,19 +21,33 @@
   </Attributes>
   <Docs>
     <summary>
-            Attribute annoted on ActionResult constructor, helper method parameters, and properties to indicate
+            Attribute annotated on ActionResult constructor, helper method parameters, and properties to indicate
             that the parameter or property is used to set the "value" for ActionResult.
             <para>
             Analyzers match this parameter by type name. This allows users to annotate custom results \ custom helpers
-            with a user defined attribute without having to expose this type.
+            with a user-defined attribute without having to expose this type.
             </para><para>
             This attribute is intentionally marked Inherited=false since the analyzer does not walk the inheritance graph.
             </para></summary>
     <remarks>To be added.</remarks>
     <example>
-            BadObjectResult([ActionResultObjectValueAttribute] object value)
-            ObjectResult { [ActionResultObjectValueAttribute] public object Value { get; set; } }
-            </example>
+    Annotated constructor parameter:
+    <code>
+      public BadRequestObjectResult([ActionResultObjectValue] object error)
+          :base(error)
+      {
+          StatusCode = DefaultStatusCode;
+      }
+    </code>
+    Annotated property:
+    <code>
+      public class ObjectResult : ActionResult, IStatusCodeActionResult
+      {
+          [ActionResultObjectValue]
+          public object Value { get; set; } 
+      }
+    </code>
+    </example>
   </Docs>
   <Members>
     <Member MemberName=".ctor">


### PR DESCRIPTION
Adds missing labels and <code> elements for the examples and fixes minor grammatical issues. Also provides more complete sample code.