### PR TITLE
add products taxonomy data in docfx.json config files

### DIFF
--- a/aspnet-core/docfx.json
+++ b/aspnet-core/docfx.json
@@ -57,6 +57,9 @@
       "ms.topic": "managed-reference",
       "ms.reviewer": "daroth",
       "ms.prod": "aspnet-core-api",
+      "products": [
+        "https://authoring-docs-microsoft.poolparty.biz/devrel/8eb81391-e81d-4461-aa4a-9512fd4bbed8"
+        ],
       "searchScope": ["ASP.NET Core"] ,
       "defaultDevLang": "csharp",
       "uhfHeaderId": "MSDocsHeader-AspNet"

--- a/aspnet-mvc/docfx.json
+++ b/aspnet-mvc/docfx.json
@@ -49,6 +49,9 @@
       "ms.topic": "managed-reference",
       "ms.reviewer": "daroth",
       "ms.prod": "aspnet-mvc-api",
+      "products": [
+        "https://authoring-docs-microsoft.poolparty.biz/devrel/8eb81391-e81d-4461-aa4a-9512fd4bbed8"
+        ],
       "searchScope": ["ASP.NET MVC"],
       "defaultDevLang": "csharp",
       "uhfHeaderId": "MSDocsHeader-AspNet"

--- a/aspnet-webpages/docfx.json
+++ b/aspnet-webpages/docfx.json
@@ -49,6 +49,9 @@
       "ms.topic": "managed-reference",
       "ms.reviewer": "daroth",
       "ms.prod": "aspnet-webpages-api",
+      "products": [
+        "https://authoring-docs-microsoft.poolparty.biz/devrel/8eb81391-e81d-4461-aa4a-9512fd4bbed8"
+        ],
       "searchScope": ["ASP.NET Web Pages"],
       "defaultDevLang": "csharp",
       "uhfHeaderId": "MSDocsHeader-AspNet"


### PR DESCRIPTION
Update 3 docfx.json files with products taxonomy info.
Docs Taxonomy URI: https://authoring-docs-microsoft.poolparty.biz/devrel/8eb81391-e81d-4461-aa4a-9512fd4bbed8  
corresponds to product name "ASP.NET". 
More granular product taxonomy would be updated if required in future, corresponding to ASP.NET Core , ASP.NET MVC.