### PR TITLE
AnchorTagHelper: seealso usage

### DIFF
--- a/aspnet-core/xml/Microsoft.AspNetCore.Mvc.TagHelpers/AnchorTagHelper.xml
+++ b/aspnet-core/xml/Microsoft.AspNetCore.Mvc.TagHelpers/AnchorTagHelper.xml
@@ -72,6 +72,7 @@
       <see cref="T:Microsoft.AspNetCore.Razor.TagHelpers.ITagHelper" /> implementation targeting &lt;a&gt; elements.
             </summary>
     <remarks>To be added.</remarks>
+    <seealso href="https://docs.microsoft.com/aspnet/core/mvc/views/tag-helpers/built-in/anchor-tag-helper">How to use</seealso>
   </Docs>
   <Members>
     <Member MemberName=".ctor">


### PR DESCRIPTION
Add an external reference to [Anchor Tag Helper in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/mvc/views/tag-helpers/built-in/anchor-tag-helper) to the page [AnchorTagHelper Class](https://docs.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.mvc.taghelpers.anchortaghelper)