### PR TITLE
Fix a hyperlink in comment

### DIFF
--- a/aspnet-core/xml/ns-Microsoft.AspNetCore.Authentication.Cookies.xml
+++ b/aspnet-core/xml/ns-Microsoft.AspNetCore.Authentication.Cookies.xml
@@ -1,6 +1,6 @@
 <Namespace Name="Microsoft.AspNetCore.Authentication.Cookies">
   <Docs>
     <summary>Contains types that support cookie based authentication.</summary>
-    <remarks>For more information about using cookie based authentication, see <see href="https://docs.microsoft.comaspnet/core/security/authentication/cookie">Use cookie authentication without ASP.NET Core Identity</see>.</remarks>
+    <remarks>For more information about using cookie based authentication, see <see href="https://docs.microsoft.com/aspnet/core/security/authentication/cookie">Use cookie authentication without ASP.NET Core Identity</see>.</remarks>
   </Docs>
 </Namespace>


### PR DESCRIPTION
Fix hyperlink of "Use cookie authentication without ASP.NET Core Identity"