### PR TITLE
Fix breadcrumbs

### DIFF
--- a/aspnet-core/breadcrumb/toc.yml
+++ b/aspnet-core/breadcrumb/toc.yml
@@ -1,7 +1,7 @@
-- name: Docs
-  tocHref: /
-  topicHref: /
+- name: .NET
+  tocHref:/dotnet/
+  topicHref: /dotnet/index
   items:
-  - name: .NET API Browser
+  - name: API browser
     tocHref: /dotnet/api/
     topicHref: /dotnet/api/index

--- a/aspnet-core/docfx.json
+++ b/aspnet-core/docfx.json
@@ -51,7 +51,6 @@
       "feedback_system": "Standard",
       "apiPlatform": "dotnet",
       "breadcrumb_path": "~/breadcrumb/toc.yml",
-      "extendBreadcrumb": true,
       "ROBOTS": "INDEX,FOLLOW",
       "author": "dotnet-bot",
       "ms.author": "riande",

--- a/aspnet-mvc/breadcrumb/toc.yml
+++ b/aspnet-mvc/breadcrumb/toc.yml
@@ -1,2 +1,7 @@
-- name: Docs
-  tocHref: /
+- name: .NET
+  tocHref:/dotnet/
+  topicHref: /dotnet/index
+  items:
+  - name: API browser
+    tocHref: /dotnet/api/
+    topicHref: /dotnet/api/index

--- a/aspnet-webpages/breadcrumb/toc.yml
+++ b/aspnet-webpages/breadcrumb/toc.yml
@@ -1,2 +1,7 @@
-- name: Docs
-  tocHref: /
+- name: .NET
+  tocHref:/dotnet/
+  topicHref: /dotnet/index
+  items:
+  - name: API browser
+    tocHref: /dotnet/api/
+    topicHref: /dotnet/api/index

--- a/aspnet-webpages/docfx.json
+++ b/aspnet-webpages/docfx.json
@@ -42,7 +42,6 @@
       "feedback_system": "Standard",
       "apiPlatform": "dotnet",
       "breadcrumb_path": "~/breadcrumb/toc.yml",
-      "extendBreadcrumb": true,
       "ROBOTS": "INDEX,FOLLOW",
       "author": "dotnet-bot",
       "ms.author": "riande",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 