### PR TITLE
Fix breadcrumbs

### DIFF
--- a/aspnet-core/aspnet-core-breadcrumb/toc.yml
+++ b/aspnet-core/aspnet-core-breadcrumb/toc.yml
@@ -1,7 +1,7 @@
-- name: .NET
+- name: ASP.NET Core
   tocHref: /dotnet/
-  topicHref: /dotnet/index
+  topicHref: /aspnet/core/index
   items:
-  - name: API browser
+  - name: .NET API browser
     tocHref: /dotnet/api/
     topicHref: /dotnet/api/index

--- a/aspnet-core/docfx.json
+++ b/aspnet-core/docfx.json
@@ -50,7 +50,7 @@
     "globalMetadata": {
       "feedback_system": "Standard",
       "apiPlatform": "dotnet",
-      "breadcrumb_path": "~/breadcrumb/toc.yml",
+      "breadcrumb_path": "/dotnet/aspnet-core-breadcrumb/toc.json",
       "ROBOTS": "INDEX,FOLLOW",
       "author": "dotnet-bot",
       "ms.author": "riande",

--- a/aspnet-mvc/aspnet-mvc-breadcrumb/toc.yml
+++ b/aspnet-mvc/aspnet-mvc-breadcrumb/toc.yml
@@ -1,7 +1,7 @@
-- name: .NET
+- name: ASP.NET Core
   tocHref: /dotnet/
-  topicHref: /dotnet/index
+  topicHref: /aspnet/core/index
   items:
-  - name: API browser
+  - name: .NET API browser
     tocHref: /dotnet/api/
     topicHref: /dotnet/api/index

--- a/aspnet-mvc/docfx.json
+++ b/aspnet-mvc/docfx.json
@@ -41,8 +41,7 @@
     "globalMetadata": {
       "feedback_system": "Standard",
       "apiPlatform": "dotnet",
-      "breadcrumb_path": "~/breadcrumb/toc.yml",
-      "extendBreadcrumb": true,
+      "breadcrumb_path": "/dotnet/aspnet-mvc-breadcrumb/toc.json",
       "ROBOTS": "INDEX,FOLLOW",
       "author": "dotnet-bot",
       "ms.author": "riande",

--- a/aspnet-webpages/aspnet-webpages-breadcrumb/toc.yml
+++ b/aspnet-webpages/aspnet-webpages-breadcrumb/toc.yml
@@ -1,7 +1,7 @@
-- name: .NET
+- name: ASP.NET Core
   tocHref: /dotnet/
-  topicHref: /dotnet/index
+  topicHref: /aspnet/core/index
   items:
-  - name: API browser
+  - name: .NET API browser
     tocHref: /dotnet/api/
     topicHref: /dotnet/api/index

--- a/aspnet-webpages/docfx.json
+++ b/aspnet-webpages/docfx.json
@@ -41,7 +41,7 @@
     "globalMetadata": {
       "feedback_system": "Standard",
       "apiPlatform": "dotnet",
-      "breadcrumb_path": "~/breadcrumb/toc.yml",
+      "breadcrumb_path": "/dotnet/aspnet-webpages-breadcrumb/toc.json",
       "ROBOTS": "INDEX,FOLLOW",
       "author": "dotnet-bot",
       "ms.author": "riande",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings and if PR Automerger service is available for this repo. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation.